### PR TITLE
Replace deprecated legacy apt keyring install

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -40,6 +40,8 @@ The following parameters are available in the `osquery` class:
 * [`repo_url`](#-osquery--repo_url)
 * [`repo_key_id`](#-osquery--repo_key_id)
 * [`repo_key_server`](#-osquery--repo_key_server)
+* [`repo_key_name`](#-osquery--repo_key_name)
+* [`repo_key_source`](#-osquery--repo_key_source)
 * [`settings`](#-osquery--settings)
 * [`validate_cmd`](#-osquery--validate_cmd)
 
@@ -152,6 +154,22 @@ Default value: `undef`
 Data type: `Optional[String]`
 
 The osquery GPG key server (apt) or GPG URL (yum)
+
+Default value: `undef`
+
+##### <a name="-osquery--repo_key_name"></a>`repo_key_name`
+
+Data type: `Optional[String]`
+
+The osquery APT keyring name
+
+Default value: `undef`
+
+##### <a name="-osquery--repo_key_source"></a>`repo_key_source`
+
+Data type: `Optional[String]`
+
+The osquery APT keyring file source
 
 Default value: `undef`
 

--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,4 +1,4 @@
 ---
 osquery::repo_url: https://pkg.osquery.io/deb
-osquery::repo_key_id: 1484120AC4E9F8A1A577AEEE97A80C63C9D8B80B
-osquery::repo_key_server: keyserver.ubuntu.com
+osquery::repo_key_name: osquery.asc
+osquery::repo_key_source: https://pkg.osquery.io/deb/pubkey.gpg

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,12 @@
 # @param repo_key_server
 #   The osquery GPG key server (apt) or GPG URL (yum)
 #
+# @param repo_key_name
+#   The osquery APT keyring name
+#
+# @param repo_key_source
+#   The osquery APT keyring file source
+#
 # @param settings
 #   A hash of settings to set in the osquery configuration file
 #
@@ -65,6 +71,8 @@ class osquery (
   Optional[String] $repo_url                   = undef,
   Optional[String] $repo_key_id                = undef,
   Optional[String] $repo_key_server            = undef,
+  Optional[String] $repo_key_name              = undef,
+  Optional[String] $repo_key_source            = undef,
   Hash $settings                               = {},
   String $validate_cmd                         = '/usr/bin/osqueryi --config_path % --config_check',
 ) {

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -13,8 +13,8 @@ class osquery::package {
           release  => 'deb',
           repos    => 'main',
           key      => {
-            id     => $osquery::repo_key_id,
-            server => $osquery::repo_key_server,
+            name   => $osquery::repo_key_name,
+            source => $osquery::repo_key_source,
           },
         }
 


### PR DESCRIPTION
Replaces the legacy `apt::key` install resulting in:

```
Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details
```